### PR TITLE
Implement GET Order Endpoint (GET /orders/{id})

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -68,11 +68,26 @@ def create_orders():
 
     # Create a message to return
     message = order.serialize()
-    # TODO: Uncomment the next line when get_order() is implemented and can be used to generate the URL for the Location header
-    # location_url = url_for("get_orders", order_id=order.id, _external=True)
-    location_url = "unknown"
+
+    location_url = url_for("get_order", order_id=order.id, _external=True)
 
     return jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
+
+
+######################################################################
+# READ AN ORDER
+######################################################################
+@app.route("/orders/<int:order_id>", methods=["GET"])
+def get_order(order_id):
+    """
+    Retrieve a single Order
+    This endpoint will return an Order based on its id
+    """
+    app.logger.info("Request to retrieve an Order with id: %s", order_id)
+    order = Order.find(order_id)
+    if not order:
+        abort(status.HTTP_404_NOT_FOUND, f"Order with id '{order_id}' was not found.")
+    return jsonify(order.serialize()), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -75,6 +75,28 @@ class TestYourResourceService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     ######################################################################
+    #  H E L P E R   M E T H O D S
+    ######################################################################
+
+    def _create_orders(self, count):
+        """Factory method to create orders in bulk"""
+        orders = []
+        for _ in range(count):
+            order = OrderFactory()
+            resp = self.client.post(
+                BASE_URL, json=order.serialize(), content_type="application/json"
+            )
+            self.assertEqual(
+                resp.status_code,
+                status.HTTP_201_CREATED,
+                "Could not create test Order",
+            )
+            new_order = resp.get_json()
+            order.id = new_order["id"]
+            orders.append(order)
+        return orders
+
+    ######################################################################
     #  C R E A T E   O R D E R   T E S T   C A S E S
     ######################################################################
 
@@ -98,16 +120,15 @@ class TestYourResourceService(TestCase):
             "Customer ID does not match",
         )
 
-        # TODO: Uncomment when get_order route is implemented
-        # # Check that the location header was correct by getting it
-        # resp = self.client.get(location, content_type="application/json")
-        # self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        # new_order = resp.get_json()
-        # self.assertEqual(
-        #     new_order["customer_id"],
-        #     order.customer_id,
-        #     "Customer ID does not match",
-        # )
+        # Check that the location header was correct by getting it
+        resp = self.client.get(location, content_type="application/json")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        new_order = resp.get_json()
+        self.assertEqual(
+            new_order["customer_id"],
+            order.customer_id,
+            "Customer ID does not match",
+        )
 
     def test_create_order_no_data(self):
         """It should not Create an Order with missing data"""
@@ -139,3 +160,26 @@ class TestYourResourceService(TestCase):
     #         BASE_URL, json=new_order, content_type="application/json"
     #     )
     #     self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    ######################################################################
+    #  R E A D   O R D E R   T E S T   C A S E S
+    ######################################################################
+
+    def test_get_order(self):
+        """It should GET a single Order by its id"""
+        order = self._create_orders(1)[0]
+        resp = self.client.get(
+            f"{BASE_URL}/{order.id}", content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        new_order = resp.get_json()
+        self.assertEqual(
+            new_order["customer_id"],
+            order.customer_id,
+            "Customer ID does not match",
+        )
+
+    def test_get_order_not_found(self):
+        """It should not GET an Order that is not found"""
+        resp = self.client.get(f"{BASE_URL}/0", content_type="application/json")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Implement GET Order Endpoint (GET /orders/{id})

- Added `GET /orders/{id}` endpoint that returns order details or 404 if not found
- Resolved TODO from create order PR: location header now returns real URL via `url_for`
- Uncommented location header verification in `test_create_order`
- Added `_create_orders` helper method for test setup
- All 30 tests passing, coverage at 95.11%

### Test Cases
- `test_get_order` — happy path, verifies 200 and correct data
- `test_get_order_not_found` — returns 404 for nonexistent order