### PR TITLE
Add GET /orders/{order_id}/items/{item_id} endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -91,6 +91,42 @@ def get_order(order_id):
 
 
 ######################################################################
+# READ AN ITEM FROM AN ORDER
+######################################################################
+@app.route("/orders/<order_id>/items/<item_id>", methods=["GET"])
+def get_order_item(order_id, item_id):
+    """
+    Retrieve an Item from an Order
+    This endpoint will return an Item based on its id within an Order
+    """
+    app.logger.info("Request to retrieve Item %s from Order %s", item_id, order_id)
+    try:
+        order_id = int(order_id)
+        item_id = int(item_id)
+    except ValueError:
+        abort(
+            status.HTTP_400_BAD_REQUEST,
+            "Invalid ID: order_id and item_id must be integers.",
+        )
+
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' was not found.",
+        )
+
+    item = Item.find(item_id)
+    if not item or item.order_id != order.id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Item with id '{item_id}' was not found in Order '{order_id}'.",
+        )
+
+    return jsonify(item.serialize()), status.HTTP_200_OK
+
+
+######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,6 +26,7 @@ from wsgi import app
 from service.common import status
 from service.models import db, Order, Item
 from tests.factories import OrderFactory
+from tests.factories import ItemFactory
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
@@ -183,3 +184,58 @@ class TestYourResourceService(TestCase):
         """It should not GET an Order that is not found"""
         resp = self.client.get(f"{BASE_URL}/0", content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    ######################################################################
+    #  R E A D   O R D E R   I T E M   T E S T   C A S E S
+    ######################################################################
+
+    def test_get_order_item(self):
+        """It should GET an Item from an Order"""
+        order = OrderFactory()
+        item = ItemFactory()
+        order_data = order.serialize()
+        order_data["items"] = [item.serialize()]
+        resp = self.client.post(
+            BASE_URL, json=order_data, content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        new_order = resp.get_json()
+        order_id = new_order["id"]
+        item_id = new_order["items"][0]["id"]
+
+        resp = self.client.get(
+            f"{BASE_URL}/{order_id}/items/{item_id}",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["id"], item_id)
+        self.assertEqual(data["order_id"], order_id)
+
+    def test_get_order_item_order_not_found(self):
+        """It should not GET an Item from a non-existing Order"""
+        resp = self.client.get(f"{BASE_URL}/0/items/1", content_type="application/json")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_order_item_not_found(self):
+        """It should not GET a non-existing Item from an Order"""
+        order = self._create_orders(1)[0]
+        resp = self.client.get(
+            f"{BASE_URL}/{order.id}/items/0",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_order_item_invalid_order_id(self):
+        """It should return 400 for an invalid order_id"""
+        resp = self.client.get(
+            f"{BASE_URL}/abc/items/1", content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_order_item_invalid_item_id(self):
+        """It should return 400 for an invalid item_id"""
+        resp = self.client.get(
+            f"{BASE_URL}/1/items/abc", content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
Added a new REST API endpoint that allows customers to view a specific item within an order.

## Endpoint
`GET /orders/{order_id}/items/{item_id}`

## Responses
- **200 OK** – Returns item details when both order and item exist
- **400 Bad Request** – Invalid order_id or item_id (non-integer)
- **404 Not Found** – Order does not exist, or item does not exist within the order

## Tests Added
- `test_get_order_item` – Retrieves an existing item from an order
- `test_get_order_item_order_not_found` – Non-existing order returns 404
- `test_get_order_item_not_found` – Non-existing item in order returns 404
- `test_get_order_item_invalid_order_id` – Invalid order_id returns 400
- `test_get_order_item_invalid_item_id` – Invalid item_id returns 400

## Test Results
- 35 tests passed
- 95.37% coverage