### PR TITLE
Modify CI To Ensure Failure When Coverage Falls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
           python -m pip install -U pip pipenv
           pipenv install --system --dev
 
-      - name: Run unit tests with nose
+      - name: Run unit tests with pytest
         run: |
-          pytest --pspec --cov=service --cov-report=xml --cov-fail-under=95
+          pytest -v --cov=service --cov-report=xml --cov-fail-under=95
         env:
           FLASK_APP: wsgi:app
           DATABASE_URI: "postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/testdb"


### PR DESCRIPTION
It's possible that --pspec in ci.yml was consuming error code output when coverage steps were running, causing steps to succeed when they should otherwise fail. This PR removes the --pspec step in order to restore intended failure behavior. 