### PR TITLE
Query Orders by Customer ID

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -95,7 +95,7 @@ def create_orders():
 
 
 ######################################################################
-# LIST ALL ORDERS
+# LIST ALL ORDERS / QUERY ORDERS BY CUSTOMER ID
 ######################################################################
 
 
@@ -103,10 +103,21 @@ def create_orders():
 def list_orders():
     """
     Retrieve a list of Orders
-    This endpoint will return all Orders
+    This endpoint will return all Orders unless a query string parameter
+    is provided to filter results. Supported query parameters:
+      - customer_id: filters orders belonging to a specific customer
+
+    If no query string is provided, all orders are returned.
+    If no orders match the filter, an empty list is returned with 200 OK.
     """
     app.logger.info("Request to list all Orders")
-    orders = Order.all()
+
+    customer_id = request.args.get("customer_id")
+    if customer_id:
+        orders = Order.query.filter(Order.customer_id == customer_id).all()
+    else:
+        orders = Order.all()
+
     results = [order.serialize() for order in orders]
     return jsonify(results), status.HTTP_200_OK
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -29,8 +29,7 @@ from tests.factories import OrderFactory
 from tests.factories import ItemFactory
 
 DATABASE_URI = os.getenv(
-    "DATABASE_URI",
-    "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+    "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
 )
 BASE_URL = "/orders"
 
@@ -86,8 +85,7 @@ class TestYourResourceService(TestCase):
         for _ in range(count):
             order = OrderFactory()
             resp = self.client.post(
-                BASE_URL, json=order.serialize(),
-                content_type="application/json"
+                BASE_URL, json=order.serialize(), content_type="application/json"
             )
             self.assertEqual(
                 resp.status_code,
@@ -135,15 +133,13 @@ class TestYourResourceService(TestCase):
 
     def test_create_order_no_data(self):
         """It should not Create an Order with missing data"""
-        resp = self.client.post(
-            BASE_URL, json={}, content_type="application/json")
+        resp = self.client.post(BASE_URL, json={}, content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_order_no_content_type(self):
         """It should not Create an Order with no content type"""
         resp = self.client.post(BASE_URL)
-        self.assertEqual(resp.status_code,
-                         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+        self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
     def test_create_order_missing_customer_id(self):
         """It should not Create an Order without a customer_id"""
@@ -186,8 +182,7 @@ class TestYourResourceService(TestCase):
 
     def test_get_order_not_found(self):
         """It should not GET an Order that is not found"""
-        resp = self.client.get(
-            f"{BASE_URL}/0", content_type="application/json")
+        resp = self.client.get(f"{BASE_URL}/0", content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     ######################################################################
@@ -219,8 +214,7 @@ class TestYourResourceService(TestCase):
 
     def test_get_order_item_order_not_found(self):
         """It should not GET an Item from a non-existing Order"""
-        resp = self.client.get(f"{BASE_URL}/0/items/1",
-                               content_type="application/json")
+        resp = self.client.get(f"{BASE_URL}/0/items/1", content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_order_item_not_found(self):
@@ -328,15 +322,13 @@ class TestYourResourceService(TestCase):
 
     def test_list_order_items_order_not_found(self):
         """It should not list Items for a non-existing Order"""
-        resp = self.client.get(f"{BASE_URL}/0/items",
-                               content_type="application/json")
+        resp = self.client.get(f"{BASE_URL}/0/items", content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_list_all_orders(self):
         """It should Get a list of Orders"""
         self._create_orders(5)
-        resp = self.client.get(f"{BASE_URL}",
-                               content_type="application/json")
+        resp = self.client.get(f"{BASE_URL}", content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
         data = resp.get_json()
@@ -344,8 +336,7 @@ class TestYourResourceService(TestCase):
 
     def test_list_order_items_invalid_order_id(self):
         """It should return 400 for an invalid order_id"""
-        resp = self.client.get(f"{BASE_URL}/abc/items",
-                               content_type="application/json")
+        resp = self.client.get(f"{BASE_URL}/abc/items", content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_list_order_items_contains_correct_data(self):
@@ -434,8 +425,7 @@ class TestYourResourceService(TestCase):
         # POST /orders/{order_id}/items
         resp = self.client.post(
             f"{BASE_URL}/{order_id}/items",
-            json={"name": item_data["name"],
-                  "quantity": item_data["quantity"]},
+            json={"name": item_data["name"], "quantity": item_data["quantity"]},
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
@@ -747,3 +737,34 @@ class TestYourResourceService(TestCase):
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    ######################################################################
+    #  Q U E R Y   O R D E R S   B Y   C U S T O M E R   I D
+    ######################################################################
+
+    def test_query_orders_by_customer_id(self):
+        """It should return only Orders that match the given customer_id"""
+        orders = self._create_orders(5)
+        target_customer_id = orders[0].customer_id
+        customer_orders = [o for o in orders if o.customer_id == target_customer_id]
+
+        resp = self.client.get(
+            f"{BASE_URL}?customer_id={target_customer_id}",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), len(customer_orders))
+        for order in data:
+            self.assertEqual(order["customer_id"], target_customer_id)
+
+    def test_query_orders_by_customer_id_no_match(self):
+        """It should return an empty list with 200 OK when no Orders match the customer_id"""
+        self._create_orders(3)
+        resp = self.client.get(
+            f"{BASE_URL}?customer_id=nonexistent999",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 0)


### PR DESCRIPTION
## Summary
Enhanced the existing `GET /orders` LIST endpoint to support filtering
orders by `customer_id` via query string parameter.

## Changes
- Updated `list_orders()` route to accept optional `?customer_id=` query parameter
- If provided, returns only orders matching that customer_id
- If omitted, returns all orders as before
- No match returns an empty list with 200 OK (not 404)

## Tests Added
- `test_query_orders_by_customer_id` — verifies filtering returns correct orders
- `test_query_orders_by_customer_id_no_match` — verifies empty list on no match

## Acceptance Criteria
- [x] `GET /orders?customer_id=123` returns only orders for customer 123
- [x] `GET /orders?customer_id=999` returns `[]` with 200 OK
- [x] `GET /orders` without query string returns all orders
- [x] 95%+ code coverage maintained