### PR TITLE
Add PUT /orders/{order_id}/cancel endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -23,7 +23,7 @@ and Delete Order
 
 from flask import jsonify, request, url_for, abort
 from flask import current_app as app  # Import Flask application
-from service.models import Order, Item
+from service.models import Order, Item, OrderStatus
 from service.common import status  # HTTP Status Codes
 
 
@@ -423,6 +423,40 @@ def check_content_type(content_type):
     abort(
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, f"Content-Type must be {content_type}"
     )
+
+
+######################################################################
+# CANCEL AN ORDER
+######################################################################
+@app.route("/orders/<order_id>/cancel", methods=["PUT"])
+def cancel_order(order_id):
+    """
+    Cancel an Order
+    This endpoint will cancel an Order by setting its status to CANCELED
+    """
+    app.logger.info("Request to cancel Order %s", order_id)
+    try:
+        order_id = int(order_id)
+    except ValueError:
+        abort(status.HTTP_400_BAD_REQUEST, "Invalid ID: order_id must be an integer.")
+
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' was not found.",
+        )
+
+    if order.status == OrderStatus.CANCELED:
+        abort(
+            status.HTTP_409_CONFLICT,
+            f"Order with id '{order_id}' is already cancelled.",
+        )
+
+    order.status = OrderStatus.CANCELED
+    order.update()
+
+    return jsonify(order.serialize()), status.HTTP_200_OK
 
 
 # Codecov baseline trigger

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -260,7 +260,7 @@ class TestYourResourceService(TestCase):
         self.assertEqual(updated_order["id"], new_order_id)
 
     def test_update_order_not_found_returns_404(self):
-        """PUT /orders/<id> should 404 when the order does not exist"""
+        """It should return 404 when the Order does not exist"""
         payload = {
             "customer_id": 1,
             "items": [],
@@ -768,3 +768,48 @@ class TestYourResourceService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 0)
+
+    ######################################################################
+    #  C A N C E L   O R D E R   T E S T   C A S E S
+    ######################################################################
+
+    def test_cancel_order(self):
+        """It should cancel an open Order"""
+        order = self._create_orders(1)[0]
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/cancel",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["status"], "CANCELED")
+
+    def test_cancel_order_not_found(self):
+        """It should return 404 when cancelling a non-existing Order"""
+        resp = self.client.put(
+            f"{BASE_URL}/999999/cancel",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_cancel_order_already_cancelled(self):
+        """It should return 409 when cancelling an already cancelled Order"""
+        order = self._create_orders(1)[0]
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/cancel",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/cancel",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT)
+
+    def test_cancel_order_invalid_id(self):
+        """It should return 400 for an invalid order_id"""
+        resp = self.client.put(
+            f"{BASE_URL}/abc/cancel",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
Adds a new action endpoint that allows managers to cancel an order by
updating its status to CANCELED. 

## Endpoint
PUT /orders/{order_id}/cancel

## Responses
- 200 OK — order successfully cancelled, returns updated order
- 400 Bad Request — invalid order_id (non-integer)
- 404 Not Found — order does not exist
- 409 Conflict — order is already cancelled

## Tests Added
- test_cancel_order — cancels an open order, verifies status is CANCELED
- test_cancel_order_not_found — returns 404 for non-existent order
- test_cancel_order_already_cancelled — returns 409 on double cancel
- test_cancel_order_invalid_id — returns 400 for non-integer ID

## Test Results
All 68 tests passing, coverage at 95%+