### PR TITLE
Implement Update Order and Item via the Web UI

### DIFF
--- a/features/orders.feature
+++ b/features/orders.feature
@@ -1,0 +1,41 @@
+Feature: Update an Order via the Web UI
+    As an eCommerce Manager
+    I need to update existing orders and items through the web interface
+    So that I can correct or modify order and item information
+
+    Background:
+        Given the following orders
+            | customer_id | status |
+            | 42          | OPEN   |
+        And the order has the following items
+            | name     | quantity | unit_price |
+            | Dog Food | 2        | 12.99      |
+
+    Scenario: Update an existing order
+        When I visit the "Home Page"
+        And I set the "ID" to the saved order id
+        And I set the "Customer ID" to "99"
+        And I select "Shipped" in the "Status" dropdown
+        And I press the "Update" button
+        Then I should see the message "Success: Order updated"
+        And I should see "99" in the "Customer ID" field
+        And I should see "Shipped" in the "Status" dropdown
+
+    Scenario: Update an item in an order
+        When I visit the "Home Page"
+        And I set the item "Order ID" to the saved order id
+        And I set the item "ID" to the saved item id
+        And I set the item "Name" to "Premium Dog Food"
+        And I set the item "Quantity" to "5"
+        And I set the item "Unit Price" to "15.99"
+        And I press the "Update Item" button
+        Then I should see the message "Success: Item updated"
+        And I should see "Premium Dog Food" in the item "Name" field
+        And I should see "5" in the item "Quantity" field
+
+    Scenario: Update an order with invalid data
+        When I visit the "Home Page"
+        And I set the "ID" to the saved order id
+        And I clear the "Customer ID" field
+        And I press the "Update" button
+        Then I should see the message "Error"

--- a/features/steps/orders_steps.py
+++ b/features/steps/orders_steps.py
@@ -25,6 +25,10 @@ For information on Waiting until elements are present in the HTML see:
 import requests
 from compare3 import expect
 from behave import given  # pylint: disable=no-name-in-module
+from behave import given, when, then
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions
 
 # HTTP Return Codes
 HTTP_200_OK = 200
@@ -32,3 +36,108 @@ HTTP_201_CREATED = 201
 HTTP_204_NO_CONTENT = 204
 
 WAIT_TIMEOUT = 60
+ITEM_PREFIX = "item_"
+
+
+######################################################################
+#  B A C K G R O U N D   S E T U P   ( R E S T   A P I )
+######################################################################
+
+
+@given("the following orders")
+def step_impl(context):
+    """Seed orders via the REST API from a Gherkin table"""
+    for row in context.table:
+        res = requests.post(
+            f"{context.base_url}/orders",
+            json={"customer_id": row["customer_id"], "status": row["status"]},
+        )
+        assert res.status_code == HTTP_201_CREATED
+        context.order_id = res.json()["id"]
+
+
+@given("the order has the following items")
+def step_impl(context):
+    """Add items to the saved order via the REST API from a Gherkin table"""
+    for row in context.table:
+        res = requests.post(
+            f"{context.base_url}/orders/{context.order_id}/items",
+            json={
+                "name": row["name"],
+                "quantity": int(row["quantity"]),
+                "unit_price": float(row["unit_price"]),
+            },
+        )
+        assert res.status_code == HTTP_201_CREATED
+        context.item_id = res.json()["id"]
+
+
+######################################################################
+#  D Y N A M I C   I D   S T E P S
+######################################################################
+
+
+@when('I set the "{field}" to the saved order id')
+def step_impl(context, field):
+    """Paste the runtime order ID into an order form field"""
+    element_id = "order_" + field.lower().replace(" ", "_")
+    element = context.driver.find_element(By.ID, element_id)
+    element.clear()
+    element.send_keys(str(context.order_id))
+
+
+@when('I set the item "{field}" to the saved order id')
+def step_impl(context, field):
+    """Paste the runtime order ID into an item form field"""
+    element_id = ITEM_PREFIX + field.lower().replace(" ", "_")
+    element = context.driver.find_element(By.ID, element_id)
+    element.clear()
+    element.send_keys(str(context.order_id))
+
+
+@when('I set the item "{field}" to the saved item id')
+def step_impl(context, field):
+    """Paste the runtime item ID into an item form field"""
+    element_id = ITEM_PREFIX + field.lower().replace(" ", "_")
+    element = context.driver.find_element(By.ID, element_id)
+    element.clear()
+    element.send_keys(str(context.item_id))
+
+
+######################################################################
+#  I T E M   F O R M   I N T E R A C T I O N S
+######################################################################
+
+
+@when('I set the item "{field}" to "{value}"')
+def step_impl(context, field, value):
+    """Type a value into an item form field"""
+    element_id = ITEM_PREFIX + field.lower().replace(" ", "_")
+    element = context.driver.find_element(By.ID, element_id)
+    element.clear()
+    element.send_keys(value)
+
+
+@then('I should see "{value}" in the item "{field}" field')
+def step_impl(context, value, field):
+    """Assert that an item form field contains the expected value"""
+    element_id = ITEM_PREFIX + field.lower().replace(" ", "_")
+    found = WebDriverWait(context.driver, context.wait_seconds).until(
+        expected_conditions.text_to_be_present_in_element_value(
+            (By.ID, element_id), value
+        )
+    )
+    assert found
+
+
+######################################################################
+#  O R D E R   F O R M   H E L P E R S
+######################################################################
+
+
+@when('I clear the "{field}" field')
+def step_impl(context, field):
+    """Clear an order form field to simulate removing required data"""
+    element_id = "order_" + field.lower().replace(" ", "_")
+    element = context.driver.find_element(By.ID, element_id)
+    element.clear()

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -32,7 +32,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select, WebDriverWait
 from selenium.webdriver.support import expected_conditions
 
-ID_PREFIX = "pet_"
+ID_PREFIX = "order_"
+
 
 def save_screenshot(context: Any, filename: str) -> None:
     """Takes a snapshot of the web page for debugging and validation
@@ -131,7 +132,7 @@ def step_impl(context: Any, element_name: str) -> None:
 
 @when('I press the "{button}" button')
 def step_impl(context: Any, button: str) -> None:
-    button_id = button.lower().replace(" ", "_") + "-btn"
+    button_id = button.lower().replace(" ", "-") + "-btn"
     context.driver.find_element(By.ID, button_id).click()
 
 

--- a/service/models/order.py
+++ b/service/models/order.py
@@ -30,10 +30,12 @@ logger = logging.getLogger("flask.app")
 
 class OrderStatus(str, Enum):
     """Order Status Enum"""
+
     OPEN = "OPEN"
     SHIPPED = "SHIPPED"
     DELIVERED = "DELIVERED"
     CANCELED = "CANCELED"
+
 
 ######################################################################
 #  O R D E R   M O D E L
@@ -49,15 +51,13 @@ class Order(db.Model, PersistentBase):
     id = db.Column(db.Integer, primary_key=True)
     customer_id = db.Column(db.String(16), nullable=False, index=True)
     # phone number is optional
-    items = db.relationship(
-        "Item", backref="order", passive_deletes=True)
+    items = db.relationship("Item", backref="order", passive_deletes=True)
     status = db.Column(
         db.Enum(OrderStatus, native=False, length=30),
         default=OrderStatus.OPEN,
         nullable=False,
     )
-    date_created = db.Column(
-        db.DateTime, nullable=False, default=datetime.utcnow)
+    date_created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __repr__(self):
         return f"<Order {self.id} items=[{self.items}]>"
@@ -68,8 +68,14 @@ class Order(db.Model, PersistentBase):
             "id": self.id,
             "customer_id": self.customer_id,
             "items": [],
-            "status": self.status.value if isinstance(self.status, OrderStatus) else self.status,
-            "date_created": self.date_created.isoformat() if self.date_created else None,
+            "status": (
+                self.status.value
+                if isinstance(self.status, OrderStatus)
+                else self.status
+            ),
+            "date_created": (
+                self.date_created.isoformat() if self.date_created else None
+            ),
         }
         for item in self.items:
             order["items"].append(item.serialize())
@@ -91,23 +97,24 @@ class Order(db.Model, PersistentBase):
                 raise DataValidationError(f"Invalid status: {status}") from error
 
             # handle inner list of items
-            items_list = data.get("items", [])
-            self.items = []
-            for json_item in items_list:
-                item = Item()
-                item.deserialize(json_item)
-                self.items.append(item)
+            if "items" in data:
+                items_list = data["items"]
+                self.items = []
+                for json_item in items_list:
+                    item = Item()
+                    item.deserialize(json_item)
+                    self.items.append(item)
         except AttributeError as error:
             raise DataValidationError(
-                "Invalid Order attribute: " + error.args[0]) from error
+                "Invalid Order attribute: " + error.args[0]
+            ) from error
         except KeyError as error:
             raise DataValidationError(
                 "Invalid Order: missing " + error.args[0]
             ) from error
         except TypeError as error:
             raise DataValidationError(
-                "Invalid Order: body of request contained bad or no data "
-                + str(error)
+                "Invalid Order: body of request contained bad or no data " + str(error)
             ) from error
 
         return self

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -138,9 +138,40 @@ $(function () {
     // ****************************************
 
     // ****************************************
-    // TODO: Update an Order
+    // Update an Order
     // #update-btn → PUT /orders/${order_id}
     // ****************************************
+
+    $("#update-btn").click(function () {
+        let order_id = $("#order_id").val();
+        if (!order_id) {
+            flash_message("Error: Order ID is required for update");
+            return;
+        }
+
+        let data = {
+            "customer_id": parseInt($("#order_customer_id").val()),
+            "status": $("#order_status").val()
+        };
+
+        $("#flash_message").empty();
+
+        let ajax = $.ajax({
+            type: "PUT",
+            url: `/orders/${order_id}`,
+            contentType: "application/json",
+            data: JSON.stringify(data),
+        });
+
+        ajax.done(function (res) {
+            update_form_data(res);
+            flash_message("Success: Order updated");
+        });
+
+        ajax.fail(function (res) {
+            flash_message("Error: " + res.responseJSON.message);
+        });
+    });
 
     // ****************************************
     // TODO: Delete an Order
@@ -173,9 +204,42 @@ $(function () {
     // ****************************************
 
     // ****************************************
-    // TODO: Update an Item in an Order
+    // Update an Item in an Order
     // #update-item-btn → PUT /orders/${order_id}/items/${item_id}
     // ****************************************
+
+    $("#update-item-btn").click(function () {
+        let order_id = $("#item_order_id").val();
+        let item_id = $("#item_id").val();
+        if (!order_id || !item_id) {
+            flash_message("Error: Order ID and Item ID are required for update");
+            return;
+        }
+
+        let data = {
+            "name": $("#item_name").val(),
+            "quantity": parseInt($("#item_quantity").val()),
+            "unit_price": parseFloat($("#item_unit_price").val())
+        };
+
+        $("#flash_message").empty();
+
+        let ajax = $.ajax({
+            type: "PUT",
+            url: `/orders/${order_id}/items/${item_id}`,
+            contentType: "application/json",
+            data: JSON.stringify(data),
+        });
+
+        ajax.done(function (res) {
+            update_item_form_data(res);
+            flash_message("Success: Item updated");
+        });
+
+        ajax.fail(function (res) {
+            flash_message("Error: " + res.responseJSON.message);
+        });
+    });
 
     // ****************************************
     // TODO: Delete an Item from an Order


### PR DESCRIPTION
## Summary
Adds UI handlers and BDD tests for updating orders and items through the web interface. 
Includes a bug fix in `Order.deserialize()` that was wiping existing items on partial updates.

## Changes
- **rest_api.js**: Added Update Order (`#update-btn → PUT /orders/{id}`) and Update Item (`#update-item-btn → PUT /orders/{id}/items/{id}`) handlers
- **order.py**: Fixed `deserialize()` to only replace items when `items` key is explicitly provided in the payload
- **web_steps.py**: Changed `ID_PREFIX` from `pet_` to `order_`, fixed button ID join character from `_` to `-`
- **orders.feature**: 3 scenarios — update order, update item, update with invalid data
- **orders_steps.py**: Table-based background setup, dynamic ID steps, item form interactions

## Bug Fix: Order.deserialize()
Previously, `deserialize()` always set `self.items = []` even when no `items` key was in the payload. 
This caused a NOT NULL violation when updating order-level fields (customer_id, status) on orders that had existing items.

## Test Results
- `make test`: 73 passed, 95.99% coverage
- `make lint`: 10.00/10
- `behave`: 3 scenarios passed, 29 steps passed