### PR TITLE
Add query orders by customer ID via web UI

### DIFF
--- a/features/orders.feature
+++ b/features/orders.feature
@@ -1,12 +1,14 @@
-Feature: Update an Order via the Web UI
+Feature: The orders service back-end
     As an eCommerce Manager
-    I need to update existing orders and items through the web interface
-    So that I can correct or modify order and item information
+    I need a RESTful orders service
+    So that I can manage orders for my customers
 
     Background:
         Given the following orders
-            | customer_id | status |
-            | 42          | OPEN   |
+            | customer_id | status  |
+            | 99          | OPEN    |
+            | 42          | SHIPPED |
+            | 42          | OPEN    |
         And the order has the following items
             | name     | quantity | unit_price |
             | Dog Food | 2        | 12.99      |
@@ -45,7 +47,7 @@ Feature: Update an Order via the Web UI
         And I set the "ID" to the saved order id
         And I press the "Delete" button
         Then I should see the message "Order successfully deleted!"
-    
+
     Scenario: Delete an existing item
         When I visit the "Home Page"
         And I set the item "Order ID" to the saved order id
@@ -59,3 +61,19 @@ Feature: Update an Order via the Web UI
         And I set the item "ID" to "99999"
         And I press the "Delete Item" button
         Then I should see the message "Error"
+
+    Scenario: Search orders by Customer ID
+        When I visit the "Home Page"
+        And I set the "Customer ID" to "42"
+        And I press the "Search" button
+        Then I should see the message "Success"
+        And I should see "42" in the results
+        And I should not see "99" in the results
+
+    Scenario: Search with no matching results
+        When I visit the "Home Page"
+        And I set the "Customer ID" to "999"
+        And I press the "Search" button
+        Then I should see the message "Success: 0 order(s) found"
+        And I should not see "42" in the results
+        And I should not see "99" in the results

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -85,6 +85,42 @@ $(function () {
         });
     }
 
+    // Builds the HTML for the orders results table
+    function build_order_table(orders) {
+        let table = '<table><colgroup>';
+        table += '<col class="col-chev"><col class="col-id"><col class="col-cust">';
+        table += '<col class="col-status"><col class="col-items"><col class="col-date">';
+        table += '</colgroup>';
+        table += '<thead><tr>';
+        table += '<th></th><th>ID</th><th>Customer</th>';
+        table += '<th>Status</th><th>Items</th><th>Created</th>';
+        table += '</tr></thead><tbody>';
+
+        for (let i = 0; i < orders.length; i++) {
+            let order = orders[i];
+            let badgeClass = status_badge_class(order.status);
+            let itemCount = order.items ? order.items.length : 0;
+
+            table += `<tr class="order-row" data-index="${i}">`;
+            table += `<td><span class="row-chevron"><svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"/></svg></span></td>`;
+            table += `<td style="font-weight:600">${order.id}</td>`;
+            table += `<td>${order.customer_id}</td>`;
+            table += `<td><span class="${badgeClass}">${order.status}</span></td>`;
+            table += `<td>${itemCount}</td>`;
+            table += `<td>${format_date(order.date_created)}</td>`;
+            table += `</tr>`;
+
+            table += `<tr class="detail-row" data-index="${i}" style="display:none;">`;
+            table += `<td colspan="6"><div class="detail-wrap"><div class="detail-inner">`;
+            table += `<p class="items-label">Order Items</p>`;
+            table += build_items_html(order.items);
+            table += `</div></div></td></tr>`;
+        }
+
+        table += '</tbody></table>';
+        return table;
+    }
+
     // Builds the HTML for an order's items sub-table
     function build_items_html(items) {
         if (!items || items.length === 0) {
@@ -187,29 +223,66 @@ $(function () {
                 url: `orders/${order_id}`,
                 type: 'DELETE',
                 dataType: 'json',
-                success: function(data) {
+                success: function (data) {
                     flash_message("Order successfully deleted!");
                     clear_form_data();
                 },
-                error: function(xhr, status, error) {
+                error: function (xhr, status, error) {
                     flash_message(`Error deleting order: ${error}`)
                 }
             });
-        } 
-        else{
+        }
+        else {
             flash_message("Please provide an order id!");
         }
     })
 
     // ****************************************
-    // TODO: List / Query Orders
-    // #search-btn → GET /orders?customer_id=X&status=Y
-    // List = no filters, Query = with filters
-    // Both handled in one click handler
-    // Each order row should have a chevron + hidden detail row
-    // that expands on click to show items via build_items_html()
-    // See test_ui_mock.js for the reference implementation
+    // List / Query Orders
+    // #search-btn → GET /orders?customer_id=X
     // ****************************************
+
+    $("#search-btn").click(function () {
+        let customer_id = $("#order_customer_id").val();
+
+        let queryString = "";
+        if (customer_id) {
+            queryString += "customer_id=" + customer_id;
+        }
+
+        $("#flash_message").empty();
+
+        let ajax = $.ajax({
+            type: "GET",
+            url: `/orders?${queryString}`,
+            contentType: "application/json",
+        });
+
+        ajax.done(function (res) {
+            $("#search_results").html(build_order_table(res));
+            update_result_count(res.length);
+            flash_message("Success: " + res.length + " order(s) found");
+
+            // Bind row click to toggle detail
+            $("#search_results .order-row").click(function () {
+                let idx = $(this).data("index");
+                $(this).toggleClass("expanded");
+                let detailRow = $(`#search_results .detail-row[data-index='${idx}']`);
+                if ($(this).hasClass("expanded")) {
+                    detailRow.show();
+                    detailRow.find(".detail-wrap").slideDown(200);
+                } else {
+                    detailRow.find(".detail-wrap").slideUp(200, function () {
+                        detailRow.hide();
+                    });
+                }
+            });
+        });
+
+        ajax.fail(function (res) {
+            flash_message("Error: " + res.responseJSON.message);
+        });
+    });
 
     // ****************************************
     // TODO: Cancel an Order (Action)
@@ -276,22 +349,22 @@ $(function () {
                 url: `orders/${order_id}/items/${item_id}`,
                 type: 'DELETE',
                 dataType: 'json',
-                success: function(data) {
+                success: function (data) {
                     flash_message("Item successfully deleted!");
                     clear_form_data();
                 },
-                error: function(xhr, status, error) {
+                error: function (xhr, status, error) {
                     flash_message(`Error deleting item: ${error}`);
                 }
             });
-        } 
+        }
         else if (!order_id && !item_id) {
             flash_message("Please provide an order id and item id!");
         }
         else if (!order_id) {
             flash_message("Please provide an order id!");
         }
-        else{
+        else {
             flash_message("Please provide an item id!");
         }
     })


### PR DESCRIPTION
## Summary
Adds UI handler and BDD tests for searching orders by customer ID through the web interface.

## Changes
- `rest_api.js`: Extracted `build_order_table()` utility function, added Search handler (`#search-btn → GET /orders?customer_id=X`), fixed expand/collapse row toggle
- `orders.feature`: Rewrote Feature header to be service-wide, added shared Background with 3 orders, added 2 query scenarios (filter by customer ID, no matching results)

## Test Results
- `behave`: 8 scenarios passed, 65 steps passed