### PR TITLE
Fixed a bug in the Web UI BDD tests

### DIFF
--- a/features/orders.feature
+++ b/features/orders.feature
@@ -81,13 +81,13 @@ Feature: The orders service back-end
         And I set the "Customer ID" to "42"
         And I press the "Search" button
         Then I should see the message "Success"
-        And I should see "42" in the results
-        And I should not see "99" in the results
+        And I should see customer id "42" in the results
+        And I should not see customer id "99" in the results
 
     Scenario: Search with no matching results
         When I visit the "Home Page"
         And I set the "Customer ID" to "999"
         And I press the "Search" button
         Then I should see the message "Success: 0 order(s) found"
-        And I should not see "42" in the results
-        And I should not see "99" in the results
+        And I should not see customer id "42" in the results
+        And I should not see customer id "99" in the results

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -149,8 +149,36 @@ def step_impl(context: Any, name: str) -> None:
 @then('I should not see "{name}" in the results')
 def step_impl(context: Any, name: str) -> None:
     element = context.driver.find_element(By.ID, "search_results")
-    assert name not in element.text
+    assert name not in element.text, f'Unexpectedly found "{name}" in results:\n {element.text}'
 
+@then('I should see customer id "{customer_id}" in the results')
+def step_impl(context: Any, customer_id: str) -> None:
+    customer_values = context.driver.execute_script("""
+        const rows = document.querySelectorAll('#search_results tr.order-row');
+        return Array.from(rows).map(row => {
+            const cols = row.querySelectorAll('td');
+            return cols.length >= 3 ? cols[2].innerText.trim() : null;
+        }).filter(v => v !== null);
+    """)
+
+    assert customer_id in customer_values, (
+        f'"{customer_id}" not found in Customer column: {customer_values}'
+    )
+
+
+@then('I should not see customer id "{customer_id}" in the results')
+def step_impl(context: Any, customer_id: str) -> None:
+    customer_values = context.driver.execute_script("""
+        const rows = document.querySelectorAll('#search_results tr.order-row');
+        return Array.from(rows).map(row => {
+            const cols = row.querySelectorAll('td');
+            return cols.length >= 3 ? cols[2].innerText.trim() : null;
+        }).filter(v => v !== null);
+    """)
+
+    assert customer_id not in customer_values, (
+        f'Unexpectedly found customer id "{customer_id}" in Customer column: {customer_values}'
+    )
 
 @then('I should see the message "{message}"')
 def step_impl(context: Any, message: str) -> None:


### PR DESCRIPTION
Fixed a bug in the Web UI BDD tests for search results verification.

Updated the result-checking steps so they validate values specifically in the Customer column instead of searching the entire search_results text block. This avoids false positives and makes the test assertions align with the actual table structure.