### PR TITLE
Add lint task to Tekton pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -64,5 +64,13 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+    - name: lint
+      taskRef:
+        name: pylint
+      runAfter:
+        - git-clone
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
   workspaces:
     - name: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -28,10 +28,30 @@ spec:
         - name: DATABASE_URI
           value: "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
       script: |
-        script: |
         #!/bin/bash
         pip install --quiet pipenv
         pipenv install --dev --system
         flask db-create
         export RETRY_COUNT=1
         python -m pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings --tb=short
+
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: pylint
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: run-lint
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/bash
+        set -e
+        pip install --quiet pipenv
+        pipenv install --dev --system
+        flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics
+        pylint service tests --max-line-length=127


### PR DESCRIPTION
### Summary

Adds a new Tekton lint task and updates the pipeline so lint and unit tests run in parallel after git-clone.

### Changes

Added a pylint task in .tekton/tasks.yaml
Configured lint to run flake8 and pylint against service and tests
Updated .tekton/pipeline.yaml so both lint and unit-test run after git-clone
Reused the shared PVC workspace across clone, lint, and test tasks

### Validation

git-clone, lint, and unit-test all succeeded
lint and unit-test started at the same time, confirming parallel execution