### PR TITLE
Add build and push image task to Tekton pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -1,14 +1,14 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: pvc-pipeline
+  name: orders-pipeline
+  namespace: barryzzzz-dev
 spec:
   params:
-    - description: The URL to the git repo
+    - description: The git repository URL to clone from
       name: GIT_REPO
       type: string
-    - default: master
-      description: The reference (branch or ref)
+    - description: The reference (branch or ref)
       name: GIT_REF
       type: string
   tasks:
@@ -56,6 +56,7 @@ spec:
       workspaces:
         - name: output
           workspace: pipeline-workspace
+
     - name: unit-test
       taskRef:
         name: pytest
@@ -64,6 +65,7 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+
     - name: lint
       taskRef:
         name: pylint
@@ -74,20 +76,21 @@ spec:
           workspace: pipeline-workspace
 
     - name: build-image
-    taskRef:
-      name: buildah
-    runAfter:
-      - unit-test
-      - lint
-    params:
-      - name: IMAGE
-        value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/orders:latest
-      - name: DOCKERFILE
-        value: ./Dockerfile
-      - name: CONTEXT
-        value: .
-    workspaces:
-      - name: source
-        workspace: pipeline-workspace
+      taskRef:
+        name: buildah
+      runAfter:
+        - unit-test
+        - lint
+      params:
+        - name: IMAGE
+          value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/orders:latest
+        - name: DOCKERFILE
+          value: ./Dockerfile
+        - name: CONTEXT
+          value: .
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
   workspaces:
     - name: pipeline-workspace

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -77,7 +77,7 @@ spec:
 
     - name: build-image
       taskRef:
-        name: buildah
+        name: buildah-nopriv
       runAfter:
         - unit-test
         - lint

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -72,5 +72,22 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+
+    - name: build-image
+    taskRef:
+      name: buildah
+    runAfter:
+      - unit-test
+      - lint
+    params:
+      - name: IMAGE
+        value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/orders:latest
+      - name: DOCKERFILE
+        value: ./Dockerfile
+      - name: CONTEXT
+        value: .
+    workspaces:
+      - name: source
+        workspace: pipeline-workspace
   workspaces:
     - name: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -55,3 +55,34 @@ spec:
         flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics
         pylint service tests --max-line-length=127
+
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: buildah
+spec:
+  workspaces:
+    - name: source
+  params:
+    - name: IMAGE
+      description: Image name to build and push
+      type: string
+    - name: DOCKERFILE
+      description: Path to Dockerfile
+      type: string
+      default: ./Dockerfile
+    - name: CONTEXT
+      description: Build context
+      type: string
+      default: .
+  steps:
+    - name: build-and-push
+      image: quay.io/buildah/stable:v1.37.0
+      workingDir: $(workspaces.source.path)
+      securityContext:
+        privileged: true
+      script: |
+        #!/bin/sh
+        buildah bud -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+        buildah push $(params.IMAGE)

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -57,10 +57,11 @@ spec:
         pylint service tests --max-line-length=127
 
 ---
+---
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: buildah
+  name: buildah-nopriv
 spec:
   workspaces:
     - name: source
@@ -80,9 +81,12 @@ spec:
     - name: build-and-push
       image: quay.io/buildah/stable:v1.37.0
       workingDir: $(workspaces.source.path)
-      securityContext:
-        privileged: true
+      env:
+        - name: STORAGE_DRIVER
+          value: vfs
+        - name: BUILDAH_ISOLATION
+          value: chroot
       script: |
         #!/bin/sh
-        buildah bud -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
-        buildah push $(params.IMAGE)
+        buildah bud --storage-driver=vfs --isolation=chroot -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+        buildah push --storage-driver=vfs --tls-verify=false $(params.IMAGE)


### PR DESCRIPTION
Implements issue #92 by adding a build-and-push task to the Tekton pipeline.

Changes:
- added a buildah task in .tekton/tasks.yaml
- added a build-image step in .tekton/pipeline.yaml
- configured the build step to run after lint and unit-test
- uses the project Dockerfile to build and push the image