### PR TITLE
Deploy PostgreSQL to OpenShift cluster

### DIFF
--- a/k8s/postgresql/statefulset.yaml
+++ b/k8s/postgresql/statefulset.yaml
@@ -1,5 +1,6 @@
 # The petstore database should be created for you, if not here is the command:
 # psql -c "create database petstore;" -U postgres
+# PostgreSQL is initialized with the configured database from postgres-config.
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
### Summary
Documents completion of the manual PostgreSQL deployment setup for OpenShift cluster testing.

### Changes
- Verified the existing k8s/postgresql manifests deploy successfully with:
  oc apply -f k8s/postgresql/
- Confirmed postgres pod, service, PVC, and credentials are correctly configured for the Orders service

### Validation
- postgres-0 reached Running state
- postgres-pvc reached Bound state
- postgres service is available on port 5432
- verified database access with:
  psql -U postgres -d orders -c '\l'
- confirmed Orders deployment expects DATABASE_URI from postgres-creds, which matches the deployed PostgreSQL configuration