### PR TITLE
Tekton task to deploy orders service to open shift

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -56,6 +56,7 @@ spec:
       workspaces:
         - name: output
           workspace: pipeline-workspace
+
     - name: unit-test
       taskRef:
         name: pytest
@@ -64,6 +65,7 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+
     - name: lint
       taskRef:
         name: pylint
@@ -72,5 +74,16 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+      
+    - name: deploy-orders
+      taskRef:
+        name: deploy-orders
+      runAfter:
+        - unit-test
+        - lint
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
   workspaces:
     - name: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -55,3 +55,49 @@ spec:
         flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics
         pylint service tests --max-line-length=127
+
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: deploy-orders
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: deploy
+      image: quay.io/openshift/origin-cli:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/bash
+        set -e
+
+        echo "Deploying Orders service to OpenShift..."
+
+        echo "Applying Orders Kubernetes/OpenShift manifests..."
+        oc apply -f k8s/deployment.yaml
+        oc apply -f k8s/service.yaml
+        oc apply -f k8s/route.yaml
+
+        echo "Waiting for Orders deployment rollout to complete..."
+        oc rollout status deployment/orders --timeout=180s
+
+        echo "Waiting for Orders pod to become Ready..."
+        oc wait --for=condition=Ready pod -l app=orders --timeout=180s
+
+        echo "Checking OpenShift route..."
+        ROUTE_HOST=$(oc get route orders -o jsonpath='{.spec.host}')
+
+        if [ -z "$ROUTE_HOST" ]; then
+          echo "ERROR: Route host is empty."
+          exit 1
+        fi
+
+        HEALTH_URL="http://${ROUTE_HOST}/health"
+        echo "Checking health endpoint: ${HEALTH_URL}"
+
+        curl -fsS "${HEALTH_URL}"
+
+        echo ""
+        echo "Orders service deployed successfully."
+        echo "Health check passed."

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -79,6 +79,12 @@ spec:
         oc apply -f k8s/service.yaml
         oc apply -f k8s/route.yaml
 
+        echo "Setting Orders image from current OpenShift project..."
+        PROJECT=$(oc project -q)
+        IMAGE="image-registry.openshift-image-registry.svc:5000/${PROJECT}/orders:latest"
+        echo "Using image: ${IMAGE}"
+        oc set image deployment/orders orders="${IMAGE}"
+
         echo "Waiting for Orders deployment rollout to complete..."
         oc rollout status deployment/orders --timeout=180s
 

--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: orders
+  labels:
+    app: orders
+spec:
+  to:
+    kind: Service
+    name: orders
+  port:
+    targetPort: 8080-tcp


### PR DESCRIPTION
### Summary

- Added an OpenShift Route manifest for the Orders service
- Added a Tekton `deploy-orders` task to apply the Orders manifests
- Updated the pipeline to run deployment after lint and unit tests
- Added rollout, pod readiness, route, and `/health` checks to fail the pipeline if deployment is unhealthy
- Dynamically resolves the current OpenShift namespace for the internal registry image instead of hardcoding a user namespace

### Testing

- Built and pushed the Orders image to the OpenShift internal registry as `orders:latest`
- Ran `pvc-pipeline` on branch `Tekton-Task-to-Deploy-Orders-Service-to-OpenShift`
- Confirmed deployment rollout completed successfully
- Confirmed both Orders pods reached Ready state
- Confirmed the OpenShift route returned `HTTP 200` from `/health`