### PR TITLE
Fix Tekton Build Task with OpenShift Binary Build

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: orders-pipeline
-  namespace: barryzzzz-dev
 spec:
   params:
     - description: The git repository URL to clone from
@@ -77,15 +76,13 @@ spec:
 
     - name: build-image
       taskRef:
-        name: buildah-nopriv
+        name: build-and-push-image
       runAfter:
         - unit-test
         - lint
       params:
         - name: IMAGE
           value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/orders:latest
-        - name: DOCKERFILE
-          value: ./Dockerfile
         - name: CONTEXT
           value: .
       workspaces:

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -57,7 +57,6 @@ spec:
         pylint service tests --max-line-length=127
 
 ---
----
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -88,5 +87,15 @@ spec:
           value: chroot
       script: |
         #!/bin/sh
-        buildah bud --storage-driver=vfs --isolation=chroot -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+        set -e
+
+        echo "Building image: $(params.IMAGE)"
+        buildah bud --storage-driver=vfs --isolation=chroot \
+          -f $(params.DOCKERFILE) \
+          -t $(params.IMAGE) \
+          $(params.CONTEXT)
+
+        echo "Pushing image: $(params.IMAGE)"
         buildah push --storage-driver=vfs --tls-verify=false $(params.IMAGE)
+
+        echo "Image build and push completed successfully."

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -60,7 +60,7 @@ spec:
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: buildah-nopriv
+  name: build-and-push-image
 spec:
   workspaces:
     - name: source
@@ -68,34 +68,39 @@ spec:
     - name: IMAGE
       description: Image name to build and push
       type: string
-    - name: DOCKERFILE
-      description: Path to Dockerfile
-      type: string
-      default: ./Dockerfile
     - name: CONTEXT
       description: Build context
       type: string
       default: .
   steps:
     - name: build-and-push
-      image: quay.io/buildah/stable:v1.37.0
+      image: quay.io/openshift/origin-cli:latest
       workingDir: $(workspaces.source.path)
-      env:
-        - name: STORAGE_DRIVER
-          value: vfs
-        - name: BUILDAH_ISOLATION
-          value: chroot
       script: |
-        #!/bin/sh
+        #!/bin/bash
         set -e
 
-        echo "Building image: $(params.IMAGE)"
-        buildah bud --storage-driver=vfs --isolation=chroot \
-          -f $(params.DOCKERFILE) \
-          -t $(params.IMAGE) \
-          $(params.CONTEXT)
+        NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 
-        echo "Pushing image: $(params.IMAGE)"
-        buildah push --storage-driver=vfs --tls-verify=false $(params.IMAGE)
+        echo "Building and pushing Orders image..."
+        echo "Namespace: ${NAMESPACE}"
+        echo "Expected image: $(params.IMAGE)"
+
+        echo "Ensuring OpenShift binary BuildConfig exists..."
+        if ! oc get bc orders -n "${NAMESPACE}" >/dev/null 2>&1; then
+          oc new-build --binary --name=orders --strategy=docker -n "${NAMESPACE}"
+        else
+          echo "BuildConfig orders already exists."
+        fi
+
+        echo "Starting binary Docker build from context: $(params.CONTEXT)"
+        oc start-build orders \
+          --from-dir="$(params.CONTEXT)" \
+          --follow \
+          --wait \
+          -n "${NAMESPACE}"
+
+        echo "Verifying pushed image stream tag..."
+        oc get istag orders:latest -n "${NAMESPACE}"
 
         echo "Image build and push completed successfully."


### PR DESCRIPTION
### Summary

- Removed the hardcoded OpenShift namespace from the Tekton pipeline so it can run in any project namespace
- Replaced the Buildah-based image build task with an OpenShift binary build task
- Added a `build-and-push-image` task that uses `oc new-build` and `oc start-build --from-dir` to build the Orders image from the project Dockerfile
- Pushes the built image to the OpenShift internal registry as `orders:latest`
- Keeps the image path namespace-agnostic using `$(context.pipelineRun.namespace)`

### Testing
- Ran the pipeline on branch fix-build:
- tkn pipeline start orders-pipeline \
  -p GIT_REPO=https://github.com/CSCI-GA-2820-SP26-003/orders \
  -p GIT_REF=fix-build \
  -w name=pipeline-workspace,claimName=pipeline-pvc \
  --showlog
- Applied the updated Tekton tasks and pipeline in my OpenShift project
- Ran `orders-pipeline` on branch `fix-build`
- Confirmed `unit-test` and `lint` completed before `build-image`
- Confirmed the image was built successfully from the Dockerfile
- Confirmed the image was pushed to the OpenShift internal registry as `orders:latest`
- Verified the image stream tag was created successfully with `oc get istag`