### PR TITLE
fix get order bug

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -27,7 +27,6 @@ from flask_restx import Api, Resource, fields
 from service.models import Order, Item, OrderStatus
 from service.common import status  # HTTP Status Codes
 
-
 ######################################################################
 # Configure Swagger before initializing it
 ######################################################################
@@ -158,12 +157,14 @@ order_base_model = api.model(
     {
         "customer_id": fields.String(
             required=True,
-            description="The id of the customer corresponding to this order"
+            description="The id of the customer corresponding to this order",
         ),
-        "items": fields.List(fields.Nested(item_model, required=False, description="The items in an order")),
-        "status": fields.String(
-            required=True, description="Status of the given order"
+        "items": fields.List(
+            fields.Nested(
+                item_model, required=False, description="The items in an order"
+            )
         ),
+        "status": fields.String(required=True, description="Status of the given order"),
     },
 )
 order_internal_model = api.inherit(
@@ -174,7 +175,9 @@ order_internal_model = api.inherit(
             readOnly=True,
             description="The unique database id assigned internally by service",
         ),
-        "date_created": fields.DateTime(readOnly=True, description="The date the order was created")
+        "date_created": fields.DateTime(
+            readOnly=True, description="The date the order was created"
+        ),
     },
 )
 
@@ -294,8 +297,7 @@ class ItemResource(Resource):
     @api.marshal_with(item_model)
     def get(self, order_id, item_id):
         """Retrieve a single Item from an Order"""
-        app.logger.info(
-            "Request to retrieve Item %s from Order %s", item_id, order_id)
+        app.logger.info("Request to retrieve Item %s from Order %s", item_id, order_id)
         try:
             order_id = int(order_id)
             item_id = int(item_id)
@@ -374,8 +376,7 @@ class ItemResource(Resource):
     @api.response(404, "Order or Item not found")
     def delete(self, order_id, item_id):
         """Delete an Item from an Order"""
-        app.logger.info(
-            "Request to delete Item %s from Order %s", item_id, order_id)
+        app.logger.info("Request to delete Item %s from Order %s", item_id, order_id)
 
         try:
             order_id = int(order_id)
@@ -437,17 +438,18 @@ def validate_item(data, name, quantity, unit_price):
             abort(status.HTTP_400_BAD_REQUEST, "unit_price must be a float")
 
     if quantity <= 0:
-        abort(status.HTTP_400_BAD_REQUEST,
-              "quantity must be a positive integer.")
+        abort(status.HTTP_400_BAD_REQUEST, "quantity must be a positive integer.")
 
 
 ######################################################################
 # UPDATE AN EXISTING ORDER
 ######################################################################
 
+
 @api.route("/orders", strict_slashes=False)
 class OrderCollection(Resource):
     """Handles interactions with the orders (no ID involved)"""
+
     @api.doc("create_order")
     @api.response(201, "Order created")
     # @api.response(404, "Order not found")
@@ -474,8 +476,7 @@ class OrderCollection(Resource):
         # Create a message to return
         message = order.serialize()
 
-        location_url = api.url_for(
-            OrderResource, order_id=order.id, _external=True)
+        location_url = api.url_for(OrderResource, order_id=order.id, _external=True)
         return message, status.HTTP_201_CREATED, {"Location": location_url}
 
 
@@ -483,10 +484,11 @@ class OrderCollection(Resource):
 @api.param("order_id", "The Order identifier")
 class OrderResource(Resource):
     """Handles interactions with a single order"""
+
     @api.doc("get_order")
     @api.response(200, "Order returned")
     @api.response(404, "Order not found")
-    @api.marshal_with(order_base_model)
+    @api.marshal_with(order_internal_model)
     def get(self, order_id):
         """
         Retrieve a single Order
@@ -495,8 +497,9 @@ class OrderResource(Resource):
         app.logger.info("Request to retrieve an Order with id: %s", order_id)
         order = Order.find(order_id)
         if not order:
-            abort(status.HTTP_404_NOT_FOUND,
-                  f"Order with id '{order_id}' was not found.")
+            abort(
+                status.HTTP_404_NOT_FOUND, f"Order with id '{order_id}' was not found."
+            )
         return order.serialize(), status.HTTP_200_OK
 
     @api.doc("update_order")
@@ -515,8 +518,9 @@ class OrderResource(Resource):
         # See if the order exists and abort if it doesn't
         order = Order.find(order_id)
         if not order:
-            abort(status.HTTP_404_NOT_FOUND,
-                  f"Order with id '{order_id}' was not found.")
+            abort(
+                status.HTTP_404_NOT_FOUND, f"Order with id '{order_id}' was not found."
+            )
 
         # Update from the json in the body of the request
         order.deserialize(request.get_json())
@@ -558,8 +562,9 @@ class OrderCancellationResource(Resource):
         try:
             order_id = int(order_id)
         except ValueError:
-            abort(status.HTTP_400_BAD_REQUEST,
-                  "Invalid ID: order_id must be an integer.")
+            abort(
+                status.HTTP_400_BAD_REQUEST, "Invalid ID: order_id must be an integer."
+            )
 
         order = Order.find(order_id)
         if not order:
@@ -597,8 +602,7 @@ def check_content_type(content_type):
     if request.headers["Content-Type"] == content_type:
         return
 
-    app.logger.error("Invalid Content-Type: %s",
-                     request.headers["Content-Type"])
+    app.logger.error("Invalid Content-Type: %s", request.headers["Content-Type"])
     abort(
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, f"Content-Type must be {content_type}"
     )

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -144,6 +144,24 @@ $(function () {
     }
 
     // ****************************************
+    // Row toggle for expanding order items
+    // (delegated so it survives table re-renders)
+    // ****************************************
+    $("#search_results").on("click", ".order-row", function () {
+        let idx = $(this).data("index");
+        $(this).toggleClass("expanded");
+        let detailRow = $(`#search_results .detail-row[data-index='${idx}']`);
+        if ($(this).hasClass("expanded")) {
+            detailRow.show();
+            detailRow.find(".detail-wrap").slideDown(200);
+        } else {
+            detailRow.find(".detail-wrap").slideUp(200, function () {
+                detailRow.hide();
+            });
+        }
+    });
+
+    // ****************************************
     // Clear the order form
     // ****************************************
 
@@ -355,20 +373,20 @@ $(function () {
             update_result_count(res.length);
             flash_message("Success: " + res.length + " order(s) found");
 
-            // Bind row click to toggle detail
-            $("#search_results .order-row").click(function () {
-                let idx = $(this).data("index");
-                $(this).toggleClass("expanded");
-                let detailRow = $(`#search_results .detail-row[data-index='${idx}']`);
-                if ($(this).hasClass("expanded")) {
-                    detailRow.show();
-                    detailRow.find(".detail-wrap").slideDown(200);
-                } else {
-                    detailRow.find(".detail-wrap").slideUp(200, function () {
-                        detailRow.hide();
-                    });
-                }
-            });
+            // // Bind row click to toggle detail
+            // $("#search_results .order-row").click(function () {
+            //     let idx = $(this).data("index");
+            //     $(this).toggleClass("expanded");
+            //     let detailRow = $(`#search_results .detail-row[data-index='${idx}']`);
+            //     if ($(this).hasClass("expanded")) {
+            //         detailRow.show();
+            //         detailRow.find(".detail-wrap").slideDown(200);
+            //     } else {
+            //         detailRow.find(".detail-wrap").slideUp(200, function () {
+            //             detailRow.hide();
+            //         });
+            //     }
+            // });
 
             document.querySelector('.res-card').scrollIntoView({ behavior: 'smooth' });
         });

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -46,14 +46,14 @@ $(function () {
         bar.removeClass("t-ok t-err");
 
         let msg = message.toLowerCase();
-        if (msg.includes("success") || msg.includes("deleted") ||
-            msg.includes("created") || msg.includes("cancel")) {
-            bar.addClass("t-ok");
-        } else if (msg.includes("error") || msg.includes("not found") ||
+        if (msg.includes("error") || msg.includes("not found") ||
             msg.includes("405") || msg.includes("409") ||
             msg.includes("415") || msg.includes("400") ||
             msg.includes("conflict")) {
             bar.addClass("t-err");
+        } else if (msg.includes("success") || msg.includes("deleted") ||
+            msg.includes("created") || msg.includes("cancel")) {
+            bar.addClass("t-ok");
         }
     }
 
@@ -132,11 +132,12 @@ $(function () {
         html += '<tbody>';
         for (let i = 0; i < items.length; i++) {
             let item = items[i];
+            let price = (item.unit_price != null) ? "$" + item.unit_price.toFixed(2) : "—";
             html += `<tr>`;
             html += `<td>${item.id}</td>`;
             html += `<td style="font-weight:600">${item.name}</td>`;
             html += `<td>${item.quantity}</td>`;
-            html += `<td>$${item.unit_price.toFixed(2)}</td>`;
+            html += `<td>${price}</td>`;
             html += `</tr>`;
         }
         html += '</tbody></table>';
@@ -563,7 +564,7 @@ $(function () {
                 dataType: 'json',
                 success: function (data) {
                     flash_message("Item successfully deleted!");
-                    clear_form_data();
+                    clear_item_form_data();
                 },
                 error: function (xhr, status, error) {
                     flash_message(`Error deleting item: ${error}`);


### PR DESCRIPTION
## Summary

Fixes a cluster of UI bugs surfaced during the final manual UI walkthrough.
The most visible was that **Get Order** displayed `Order #undefined` and a
missing date in the results table, even though the form fields filled in
correctly. Investigation surfaced four additional smaller issues in the
frontend that are bundled here.

## Changes

### Backend

- `service/routes.py`: changed `OrderResource.get` from
  `@api.marshal_with(order_base_model)` to
  `@api.marshal_with(order_internal_model)`. The base model only declares
  `customer_id`, `items`, and `status`, so Flask-RESTX was silently
  stripping `id` and `date_created` from the GET response. The internal
  model is the same one already used by POST and PUT, so this aligns the
  three endpoints.

### Frontend (`service/static/js/rest_api.js`)

- Added a delegated click handler on `#search_results` for `.order-row` so
  the expand/collapse toggle survives table re-renders. Previously the
  handler was bound only inside the `#search-btn` done callback, so rows
  rendered by Get Order were inert.
- Fixed `#delete-item-btn` success callback to call `clear_item_form_data()`
  instead of `clear_form_data()` — it was wiping the order form on item
  deletion.
- Reordered the keyword checks in `flash_message()` so error messages
  containing "cancel" (e.g. "Error: Unable to cancel order") render as red
  toasts instead of green.
- Guarded `build_items_html()` against null `unit_price` — the backend
  treats `unit_price` as optional, so items without a price now render
  with `—` instead of throwing `Cannot read properties of null`.

## Notes

- No changes to any DOM IDs, button wiring, or form-fill flow, so Behave
  scenarios are unaffected.
- The marshalling fix is a strict superset of fields — adds `id` and
  `date_created` where they were missing, doesn't change anything that
  was already returned. No unit test changes needed.
- Verified with `make test`, `make lint`, and `behave` all green.
- Verified manually in the UI: Get Order, Search Orders, row expand,
  Cancel Order error toast, item delete, and an item created with null
  unit_price all render correctly.

## Tests Added

None — this is a bugfix PR for UI rendering issues. The existing test
suite already exercises the affected endpoints and `serialize()` outputs;
the fixes were in marshalling and JS rendering, both of which are
verified by manual UI walkthrough and the existing Behave scenarios.

## Test Results

- `make test`: passing, coverage maintained at 95%+
- `make lint`: clean
- `behave`: all scenarios passing
- Manual UI: Get Order shows correct ID + date, row toggle works after
  Get Order and Search, error toasts are red, items with null prices
  render as `—`.